### PR TITLE
使用していない環境変数を削除します

### DIFF
--- a/.changeset/tame-buckets-serve.md
+++ b/.changeset/tame-buckets-serve.md
@@ -1,0 +1,5 @@
+---
+'todo-sstv2-sveltekit': patch
+---
+
+chore: 使用していない環境変数を削除します

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DATABASE_URL=""

--- a/packages/frontend/.env.example
+++ b/packages/frontend/.env.example
@@ -1,1 +1,0 @@
-DATABASE_URL="postgres://root:mysecretpassword@localhost:5432/local"

--- a/stacks/MyStack.ts
+++ b/stacks/MyStack.ts
@@ -22,7 +22,6 @@ export function API({ stack }: StackContext) {
     path: 'packages/frontend',
     bind: [dynamoDb],
     environment: {
-      DATABASE_URL: process.env.DATABASE_URL || '',
       BACKEND_BASE_URL: api.url,
     },
   })


### PR DESCRIPTION
## 概要

データの永続化先をDynamoDBに変更したため、環境変数`DATABASE_URL`は不要になりました。